### PR TITLE
Add sync lock for fetching all task keys

### DIFF
--- a/pkg/web/taskmgr.go
+++ b/pkg/web/taskmgr.go
@@ -19,6 +19,8 @@ func newTaskMgr() *taskMgr {
 }
 
 func (m *taskMgr) keys() []string {
+	m.mux.Lock()
+	defer m.mux.Unlock()
 	var keys []string
 	for k := range m.tasks {
 		keys = append(keys, k)


### PR DESCRIPTION
Task manager should lock the shared tasks data used by multiple requests from http clients.