### PR TITLE
Fix the import of files with wildcard in the path when under the path…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,11 +384,6 @@ func (f *File) expandFiles(dir string, runnerLogger *logger.RunnerLogger) (err e
 			return err, files
 		}
 
-		if len(fileNames) == 1 {
-			files = append(files, f)
-			return err, files
-		}
-
 		for i := range fileNames {
 			var failedDataPath *string = nil
 			if f.FailDataPath != nil {


### PR DESCRIPTION
for example , the path ./csv/*.csv 
and under the path ./csv/ only has one file  ./csv/a.csv ,
the importer will fail with error msg `‘cannot find file File(./csv/*.csv) doesnot exist!’`