### PR TITLE
cmd add extra parameters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,19 @@ func isSupportedVersion(ver string) bool {
 	return false
 }
 
+func UpdateParse(filename string, yamlConf *YAMLConfig) error {
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return ierrors.Wrap(ierrors.InvalidConfigPathOrFormat, err)
+	}
+	path := filepath.Dir(abs)
+	if err = yamlConf.ValidateAndReset(path); err != nil {
+		return ierrors.Wrap(ierrors.ConfigError, err)
+	}
+
+	return nil
+}
+
 func Parse(filename string, runnerLogger logger.Logger) (*YAMLConfig, error) {
 	logger.SetLogger(runnerLogger)
 	content, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
Startup parameter added file path that can configure tag/edgeType. 
Priority: Startup Parameter > Configuration File. The default parameter is configuration file.
Cmd  parameter style like: {tag name/edgeType name}={path}, example: person=/home/user/person.csv，Support for multiple parameters, multiple same tag/edgeType are not supported.

Startup command like:
 ./nebula-importer --config <yaml_config_file_path> <tag_name>=<new_data_path01> <edgetype_name>=<new_data_path02>