### PR TITLE
Add source format flag

### DIFF
--- a/pkg/reader/record.go
+++ b/pkg/reader/record.go
@@ -2,8 +2,14 @@
 package reader
 
 import (
+	"strings"
+
 	"github.com/vesoft-inc/nebula-importer/v4/pkg/source"
 	"github.com/vesoft-inc/nebula-importer/v4/pkg/spec"
+)
+
+const (
+	FormatCSV = "csv"
 )
 
 type (
@@ -15,6 +21,17 @@ type (
 )
 
 func NewRecordReader(s source.Source) RecordReader {
+	format := strings.ToLower(strings.TrimSpace(s.Config().Format))
+
+	if format == "" {
+		// default format
+		format = FormatCSV
+	}
+	switch format {
+	case FormatCSV:
+		return NewCSVReader(s)
 	// TODO: support other source formats
-	return NewCSVReader(s)
+	default:
+		panic("unsupported source format")
+	}
 }

--- a/pkg/reader/record_test.go
+++ b/pkg/reader/record_test.go
@@ -30,4 +30,11 @@ var _ = Describe("RecordReader", func() {
 		r := NewRecordReader(s)
 		Expect(r).NotTo(BeNil())
 	})
+	It("should panic", func() {
+		s.Config().Format = "unknown"
+
+		Expect(func() {
+			NewRecordReader(s)
+		}).Should(PanicWith("unsupported source format"))
+	})
 })

--- a/pkg/source/config.go
+++ b/pkg/source/config.go
@@ -2,13 +2,14 @@ package source
 
 type (
 	Config struct {
-		Local *LocalConfig `yaml:",inline"`
-		S3    *S3Config    `yaml:"s3,omitempty"`
-		OSS   *OSSConfig   `yaml:"oss,omitempty"`
-		FTP   *FTPConfig   `yaml:"ftp,omitempty"`
-		SFTP  *SFTPConfig  `yaml:"sftp,omitempty"`
-		HDFS  *HDFSConfig  `yaml:"hdfs,omitempty"`
-		GCS   *GCSConfig   `yaml:"gcs,omitempty"`
+		Format string       `yaml:"format,omitempty"`
+		Local  *LocalConfig `yaml:",inline"`
+		S3     *S3Config    `yaml:"s3,omitempty"`
+		OSS    *OSSConfig   `yaml:"oss,omitempty"`
+		FTP    *FTPConfig   `yaml:"ftp,omitempty"`
+		SFTP   *SFTPConfig  `yaml:"sftp,omitempty"`
+		HDFS   *HDFSConfig  `yaml:"hdfs,omitempty"`
+		GCS    *GCSConfig   `yaml:"gcs,omitempty"`
 		// The following is format information
 		CSV *CSVConfig `yaml:"csv,omitempty"`
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

Add a new flag `format` for the future parquet and other format supports.
Currently keep the CSV as default, will add the config field to the document after the Parquet support is implemented.
Avoid confusing the end users.

#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


